### PR TITLE
Support send-only endpoints

### DIFF
--- a/src/ServiceControl.Plugin.Nsb6.Heartbeat/Heartbeats.cs
+++ b/src/ServiceControl.Plugin.Nsb6.Heartbeat/Heartbeats.cs
@@ -13,9 +13,12 @@
     using NServiceBus.Transports;
     using Plugin.Heartbeat.Messages;
 
-    class Heartbeats : Feature
+    /// <summary>
+    /// The ServiceControl.Heartbeat plugin.
+    /// </summary>
+    public class Heartbeats : Feature
     {
-        public Heartbeats()
+        internal Heartbeats()
         {
             EnableByDefault();
 
@@ -24,6 +27,7 @@
             Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "The Heartbeats plugin currently isn't supported for Send-Only endpoints");
         }
 
+        /// <summary>Called when the features is activated.</summary>
         protected override void Setup(FeatureConfigurationContext context)
         {
             if (!VersionChecker.CoreVersionIsAtLeast(4, 4))

--- a/src/ServiceControl.Plugin.Nsb6.Heartbeat/Heartbeats.cs
+++ b/src/ServiceControl.Plugin.Nsb6.Heartbeat/Heartbeats.cs
@@ -21,10 +21,6 @@
         internal Heartbeats()
         {
             EnableByDefault();
-
-            // we need a mechanism to start and stop to register and stop heartbeats timers.
-            // and both StartupTasks and IWantToRunWhenBusStartsAndStops aren't supported for send-only endpoints.
-            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "The Heartbeats plugin currently isn't supported for Send-Only endpoints");
         }
 
         /// <summary>Called when the features is activated.</summary>


### PR DESCRIPTION
Since `FeatureStartupTask`s are run for send-only endpoints in v6, there is no need to disable the plugin for send-only endpoints.

Connects to Particular/PlatformDevelopment#757
